### PR TITLE
Added Northern Ireland geography and area selection AND corresponding jitter plots

### DIFF
--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -522,60 +522,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
       } else if (selected$geography == "northern_ireland_ltla_shp" & type == "secondary_care") {
         tagList(
           tags$p(
-            "Secondary care indicators report on the direct performance of the national
-         health service. Most secondary care statistics are reported only at
-         the Trust level. To be able to view these statistics at the local authority
-         level, we have aggregated them using catchment population data.
-         For more information on how we have done this, see ",
-            tags$a(
-              href = "https://britishredcrosssociety.github.io/resilience-index-book/technical.html#health-capacity---england",
-              target = "_blank",
-              "here."
-            )
-          ),
-          tags$p(
-            "The Improving Access to Pyschological Therapies (IAPT) programme offers
-        talking therapies for mental health problems. To address both access to
-        mental health services and the success rate of their interventions, the
-        percentage of referrals that were able to access a service within 18
-        weeks and also finished the first course of treatment are presented.
-        More detailed statistics can be accessed ",
-            tags$a(
-              href = "https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets/improving-access-to-psychological-therapies-data-set/improving-access-to-psychological-therapies-data-set-reports",
-              target = "_blank",
-              "here."
-            )
-          ),
-          tags$p(
-            "Discharged beds indicates the total number of patients discharged from
-        beds, and the percentage this makes up of all beds. More detailed
-        breakdowns can be viewed ",
-            tags$a(
-              href = "https://www.england.nhs.uk/statistics/statistical-work-areas/discharge-delays-acute-data/",
-              target = "_blank",
-              "here."
-            )
-          ),
-          tags$p(
-            "Beds not meeting criteria to reside shows the number of patients who
-        are no longer eligible to occupy a bed, and the percentage of these of
-        all beds. This indicator is often a good proxy for where social care is
-        low. For a more detailed breakdown, see",
-            tags$a(
-              href = "https://www.england.nhs.uk/statistics/statistical-work-areas/discharge-delays-acute-data/",
-              target = "_blank",
-              "here."
-            )
-          ),
-          tags$p(
-            "In addition to the bed availability indicator presented above, our team
-         has also produced a NHS England winter situation report explorer, with
-         detailed breakdowns by type of bed, which can be seen ",
-            tags$a(
-              href = "https://britishredcross.shinyapps.io/sitrep-explorer/",
-              target = "_blank",
-              "here."
-            )
+            "Provision of unpaid care [...]"
           )
         )
 
@@ -658,60 +605,13 @@ indicatorDescriptionsServer <- function(id, selected, type) {
       } else if (selected$geography == "northern_ireland_hsct_shp" & type == "secondary_care") {
         tagList(
           tags$p(
-            "Secondary care indicators report on the direct performance of the national
-         health service. Most secondary care statistics are reported only at
-         the Trust level. To be able to view these statistics at the local authority
-         level, we have aggregated them using catchment population data.
-         For more information on how we have done this, see ",
-            tags$a(
-              href = "https://britishredcrosssociety.github.io/resilience-index-book/technical.html#health-capacity---england",
-              target = "_blank",
-              "here."
-            )
+            "Referral to treatment waiting times show the number of people waiting
+            over 18 weeks from their intial referral to the start of their
+            treatment."
           ),
           tags$p(
-            "The Improving Access to Pyschological Therapies (IAPT) programme offers
-        talking therapies for mental health problems. To address both access to
-        mental health services and the success rate of their interventions, the
-        percentage of referrals that were able to access a service within 18
-        weeks and also finished the first course of treatment are presented.
-        More detailed statistics can be accessed ",
-            tags$a(
-              href = "https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets/improving-access-to-psychological-therapies-data-set/improving-access-to-psychological-therapies-data-set-reports",
-              target = "_blank",
-              "here."
-            )
-          ),
-          tags$p(
-            "Discharged beds indicates the total number of patients discharged from
-        beds, and the percentage this makes up of all beds. More detailed
-        breakdowns can be viewed ",
-            tags$a(
-              href = "https://www.england.nhs.uk/statistics/statistical-work-areas/discharge-delays-acute-data/",
-              target = "_blank",
-              "here."
-            )
-          ),
-          tags$p(
-            "Beds not meeting criteria to reside shows the number of patients who
-        are no longer eligible to occupy a bed, and the percentage of these of
-        all beds. This indicator is often a good proxy for where social care is
-        low. For a more detailed breakdown, see",
-            tags$a(
-              href = "https://www.england.nhs.uk/statistics/statistical-work-areas/discharge-delays-acute-data/",
-              target = "_blank",
-              "here."
-            )
-          ),
-          tags$p(
-            "In addition to the bed availability indicator presented above, our team
-         has also produced a NHS England winter situation report explorer, with
-         detailed breakdowns by type of bed, which can be seen ",
-            tags$a(
-              href = "https://britishredcross.shinyapps.io/sitrep-explorer/",
-              target = "_blank",
-              "here."
-            )
+            "Bed availability shows the number of available staffed beds across
+            all specialties"
           )
         )
 

--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -544,7 +544,6 @@ indicatorDescriptionsServer <- function(id, selected, type) {
         # ---- northern_ireland_hsct_summary_metrics ----
       } else if (selected$geography == "northern_ireland_hsct_shp" & type == "summary_metrics") {
         tagList(
-          tagList(
           tags$p(
             "These indicators summarise a selection of health metrics into a single
         score. They can be useful for comparing the overall health of different
@@ -600,7 +599,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- northern_ireland_hsct_secondary_care ----
       } else if (selected$geography == "northern_ireland_hsct_shp" & type == "secondary_care") {
         tagList(
@@ -614,7 +613,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             all specialties"
           )
         )
-
+        
         # ---- northern_ireland_hsct_demographics ----
       } else if (selected$geography == "northern_ireland_hsct_shp" & type == "demographics") {
         tagList(
@@ -642,7 +641,7 @@ indicatorDescriptionsTest <- function() {
     selected <- reactiveValues(
       areas = vector(), geography = "northern_ireland_ltla_shp"
     )
-    indicatorDescriptionsServer("test", selected, type = "demographics")
+    indicatorDescriptionsServer("test", selected, type = "secondary_care")
   }
   shinyApp(ui, server)
 }

--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -55,7 +55,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- england_ltla_secondary_care ----
       } else if (selected$geography == "england_ltla_shp" & type == "secondary_care") {
         tagList(
@@ -116,7 +116,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- england_ltla_demographics ----
       } else if (selected$geography == "england_ltla_shp" & type == "demographics") {
         tagList(
@@ -131,7 +131,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- england_icb_summary_metrics ----
       } else if (selected$geography == "england_icb_shp" & type == "summary_metrics") {
         tagList(
@@ -182,7 +182,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- england_icb_secondary_care ----
       } else if (selected$geography == "england_icb_shp" & type == "secondary_care") {
         tagList(
@@ -243,7 +243,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- england_icb_demographics ----
       } else if (selected$geography == "england_icb_shp" & type == "demographics") {
         tagList(
@@ -258,7 +258,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- scotland_ltla_summary_metrics ----
       } else if (selected$geography == "scotland_ltla_shp" & type == "summary_metrics") {
         tagList(
@@ -318,7 +318,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- scotland_ltla_secondary_care ----
       } else if (selected$geography == "scotland_ltla_shp" & type == "secondary_care") {
         tagList(
@@ -333,7 +333,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- scotland_ltla_demographics ----
       } else if (selected$geography == "scotland_ltla_shp" & type == "demographics") {
         tagList(
@@ -348,7 +348,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- scotland_hb_summary_metrics ----
       } else if (selected$geography == "scotland_hb_shp" & type == "summary_metrics") {
         tagList(
@@ -408,7 +408,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- scotland_hb_secondary_care ----
       } else if (selected$geography == "scotland_hb_shp" & type == "secondary_care") {
         tagList(
@@ -444,7 +444,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-
+        
         # ---- scotland_hb_demographics ----
       } else if (selected$geography == "scotland_hb_shp" & type == "demographics") {
         tagList(
@@ -459,7 +459,260 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-      }
+        # ---- northern_ireland_ltla_summary_metrics ----
+      } else if (selected$geography == "northern_ireland_ltla_shp" & type == "summary_metrics") {
+        tagList(
+          tags$p(
+            "These indicators summarise a selection of health metrics into a single
+        score. They can be useful for comparing the overall health of different
+        areas and are a good place to start. But, they should not be used in
+        isolation to make judgements about all aspects of an area's health. For
+        example, an area may score poorly in a summary metric, yet still excel
+        in certain aspects of health."
+          ),
+          tags$p(
+            "The ONS Health Index provides an indication of health outcomes, risk
+        factors, and the wider determinants of health. A detailed breakdown
+        of the index can be viewed ",
+            tags$a(
+              href = "https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/bulletins/healthinengland/2015to2021",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "Left-behind areas are places high in deprivation and socio-economic
+        challenges, and low in social infrastructure and investment to meet those
+        challenges. Research has shown they are associated with high health
+        inequalities. More information on these areas can be found ",
+            tags$a(
+              href = "https://ocsi.uk/left-behind-neighbourhoods/",
+              target = "_blank",
+              "here."
+            ),
+            " An interactice map to visualise these areas can be found",
+            tags$a(
+              href = "https://britishredcross.shinyapps.io/left-behind-areas/",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "The Indices of Multiple Deprivation (IMD) include a measure of health
+        that measures the risk of premature death and the impairment of quality
+        of life through poor physical or mental health. More information can be
+        viewed ",
+            tags$a(
+              href = "https://www.gov.uk/government/statistics/english-indices-of-deprivation-2019",
+              target = "_blank",
+              "here."
+            )
+          )
+        )
+        
+        # ---- northern_ireland_ltla_secondary_care ----
+      } else if (selected$geography == "northern_ireland_ltla_shp" & type == "secondary_care") {
+        tagList(
+          tags$p(
+            "Secondary care indicators report on the direct performance of the national
+         health service. Most secondary care statistics are reported only at
+         the Trust level. To be able to view these statistics at the local authority
+         level, we have aggregated them using catchment population data.
+         For more information on how we have done this, see ",
+            tags$a(
+              href = "https://britishredcrosssociety.github.io/resilience-index-book/technical.html#health-capacity---england",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "The Improving Access to Pyschological Therapies (IAPT) programme offers
+        talking therapies for mental health problems. To address both access to
+        mental health services and the success rate of their interventions, the
+        percentage of referrals that were able to access a service within 18
+        weeks and also finished the first course of treatment are presented.
+        More detailed statistics can be accessed ",
+            tags$a(
+              href = "https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets/improving-access-to-psychological-therapies-data-set/improving-access-to-psychological-therapies-data-set-reports",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "Discharged beds indicates the total number of patients discharged from
+        beds, and the percentage this makes up of all beds. More detailed
+        breakdowns can be viewed ",
+            tags$a(
+              href = "https://www.england.nhs.uk/statistics/statistical-work-areas/discharge-delays-acute-data/",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "Beds not meeting criteria to reside shows the number of patients who
+        are no longer eligible to occupy a bed, and the percentage of these of
+        all beds. This indicator is often a good proxy for where social care is
+        low. For a more detailed breakdown, see",
+            tags$a(
+              href = "https://www.england.nhs.uk/statistics/statistical-work-areas/discharge-delays-acute-data/",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "In addition to the bed availability indicator presented above, our team
+         has also produced a NHS England winter situation report explorer, with
+         detailed breakdowns by type of bed, which can be seen ",
+            tags$a(
+              href = "https://britishredcross.shinyapps.io/sitrep-explorer/",
+              target = "_blank",
+              "here."
+            )
+          )
+        )
+        
+        # ---- northern_ireland_ltla_demographics ----
+      } else if (selected$geography == "northern_ireland_ltla_shp" & type == "demographics") {
+        tagList(
+          tags$p(
+            "These indicators can be used alongside other indicators to understand
+        the population breakdowns of the areas being assesed. All data come from
+        the latest ",
+            tags$a(
+              href = "https://www.ons.gov.uk/census",
+              target = "_blank",
+              "2021 census."
+            )
+          )
+        )
+        
+        # ---- northern_ireland_hsct_summary_metrics ----
+      } else if (selected$geography == "northern_ireland_hsct_shp" & type == "summary_metrics") {
+        tagList(
+          tags$p(
+            "These indicators summarise a selection of health metrics into a single
+        score. They can be useful for comparing the overall health of different
+        areas and are a good place to start. But, they should not be used in
+        isolation to make judgements about all aspects of an area's health. For
+        example, an area may score poorly in a summary metric, yet still excel
+        in certain aspects of health."
+          ),
+          tags$p(
+            "The ONS Health Index provides an indication of health outcomes, risk
+        factors, and the wider determinants of health. A detailed breakdown
+        of the index can be viewed ",
+            tags$a(
+              href = "https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/bulletins/healthinengland/2015to2021",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "Left-behind areas are places high in deprivation and socio-economic
+        challenges, and low in social infrastructure and investment to meet those
+        challenges. Research has shown they are associated with high health
+        inequalities. More information on these areas can be found ",
+            tags$a(
+              href = "https://ocsi.uk/left-behind-neighbourhoods/",
+              target = "_blank",
+              "here."
+            ),
+            " An interactice map to visualise these areas can be found",
+            tags$a(
+              href = "https://britishredcross.shinyapps.io/left-behind-areas/",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "The Indices of Multiple Deprivation (IMD) include a measure of health
+        that measures the risk of premature death and the impairment of quality
+        of life through poor physical or mental health. More information can be
+        viewed ",
+            tags$a(
+              href = "https://www.gov.uk/government/statistics/english-indices-of-deprivation-2019",
+              target = "_blank",
+              "here."
+            )
+          )
+        )
+        
+        # ---- northern_ireland_hsct_secondary_care ----
+      } else if (selected$geography == "northern_ireland_hsct_shp" & type == "secondary_care") {
+        tagList(
+          tags$p(
+            "Secondary care indicators report on the direct performance of the national
+         health service. Most secondary care statistics are reported only at
+         the Trust level. To be able to view these statistics at the local authority
+         level, we have aggregated them using catchment population data.
+         For more information on how we have done this, see ",
+            tags$a(
+              href = "https://britishredcrosssociety.github.io/resilience-index-book/technical.html#health-capacity---england",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "The Improving Access to Pyschological Therapies (IAPT) programme offers
+        talking therapies for mental health problems. To address both access to
+        mental health services and the success rate of their interventions, the
+        percentage of referrals that were able to access a service within 18
+        weeks and also finished the first course of treatment are presented.
+        More detailed statistics can be accessed ",
+            tags$a(
+              href = "https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets/improving-access-to-psychological-therapies-data-set/improving-access-to-psychological-therapies-data-set-reports",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "Discharged beds indicates the total number of patients discharged from
+        beds, and the percentage this makes up of all beds. More detailed
+        breakdowns can be viewed ",
+            tags$a(
+              href = "https://www.england.nhs.uk/statistics/statistical-work-areas/discharge-delays-acute-data/",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "Beds not meeting criteria to reside shows the number of patients who
+        are no longer eligible to occupy a bed, and the percentage of these of
+        all beds. This indicator is often a good proxy for where social care is
+        low. For a more detailed breakdown, see",
+            tags$a(
+              href = "https://www.england.nhs.uk/statistics/statistical-work-areas/discharge-delays-acute-data/",
+              target = "_blank",
+              "here."
+            )
+          ),
+          tags$p(
+            "In addition to the bed availability indicator presented above, our team
+         has also produced a NHS England winter situation report explorer, with
+         detailed breakdowns by type of bed, which can be seen ",
+            tags$a(
+              href = "https://britishredcross.shinyapps.io/sitrep-explorer/",
+              target = "_blank",
+              "here."
+            )
+          )
+        )
+        
+        # ---- northern_ireland_hsct_demographics ----
+      } else if (selected$geography == "northern_ireland_hsct_shp" & type == "demographics") {
+        tagList(
+          tags$p(
+            "These indicators can be used alongside other indicators to understand
+        the population breakdowns of the areas being assesed. All data come from
+        the latest ",
+            tags$a(
+              href = "https://www.ons.gov.uk/census",
+              target = "_blank",
+              "2021 census."
+            )
+          )
+        )
+      } 
     })
   })
 }

--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -479,9 +479,8 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             ),
             " is England specific and provides an indication of health outcomes,
             risk factors, and the wider determinants of health. As part of the
-            British Red Cross Resilience Index, an equivalent version for Northern Ireland
-            was created. More details of this index can
-            be viewed ",
+            British Red Cross Resilience Index, an equivalent version for 
+            Northern Ireland was created. More details of this index can be viewed ",
             tags$a(
               href = "https://github.com/britishredcrosssociety/resilience-index",
               target = "_blank",
@@ -522,7 +521,16 @@ indicatorDescriptionsServer <- function(id, selected, type) {
       } else if (selected$geography == "northern_ireland_ltla_shp" & type == "secondary_care") {
         tagList(
           tags$p(
-            "Provision of unpaid care [...]"
+            "Provision of unpaid care covers looking after, giving help or support 
+            to anyone because they have long-term physical or mental health 
+            conditions or illnesses, or problems related to old age. It excludes 
+            any activities carried out in paid employment. More information can 
+            be viewed ",
+            tags$a(
+              href = "https://www.nisra.gov.uk/publications/census-2021-main-statistics-health-disability-and-unpaid-care-tables"
+              target = "_blank",
+              "here."
+            )
           )
         )
 

--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -414,7 +414,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
         tagList(
           tags$p(
             "Referral to treatment waiting times show the number of people waiting
-            over 18 weeks from their intial referral to the start of their
+            over 18 weeks from their initial referral to the start of their
             treatment. The Scottish Government determined that at least
             90% of patients should be seen within at least 18 weeks. More
             information can be viewed ",
@@ -527,7 +527,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             any activities carried out in paid employment. More information can 
             be viewed ",
             tags$a(
-              href = "https://www.nisra.gov.uk/publications/census-2021-main-statistics-health-disability-and-unpaid-care-tables"
+              href = "https://www.nisra.gov.uk/publications/census-2021-main-statistics-health-disability-and-unpaid-care-tables",
               target = "_blank",
               "here."
             )
@@ -613,12 +613,29 @@ indicatorDescriptionsServer <- function(id, selected, type) {
         tagList(
           tags$p(
             "Referral to treatment waiting times show the number of people waiting
-            over 18 weeks from their intial referral to the start of their
-            treatment."
+            over 18 weeks from their initial referral to the start of their
+            treatment. More information can be viewed ",
+            tags$a(
+              href = "https://www.health-ni.gov.uk/publications/northern-ireland-waiting-time-statistics-inpatient-and-day-case-waiting-times-december-2022",
+              target = "_blank",
+              "here"
+            ),
+            " for inpatient and day case waiting times, and ",
+            tags$a(
+              href = "https://www.health-ni.gov.uk/publications/northern-ireland-waiting-time-statistics-outpatient-waiting-times-december-2022",
+              target = "_blank",
+              "here"
+            ),
+            " for outpatient waiting times."
           ),
           tags$p(
             "Bed availability shows the number of available staffed beds across
-            all specialties"
+            all specialties. More information can be viewed ",
+            tags$a(
+              href = "https://www.health-ni.gov.uk/publications/hospital-statistics-inpatient-and-day-case-activity-202122",
+              target = "_blank",
+              "here."
+            )
           )
         )
         
@@ -647,7 +664,7 @@ indicatorDescriptionsTest <- function() {
   )
   server <- function(input, output, session) {
     selected <- reactiveValues(
-      areas = vector(), geography = "northern_ireland_ltla_shp"
+      areas = vector(), geography = "northern_ireland_hsct_shp"
     )
     indicatorDescriptionsServer("test", selected, type = "secondary_care")
   }

--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -510,7 +510,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
         of life through poor physical or mental health. More information can be
         viewed ",
             tags$a(
-              href = "https://www.gov.uk/government/statistics/english-indices-of-deprivation-2019",
+              href = "https://www.nisra.gov.uk/statistics/deprivation/northern-ireland-multiple-deprivation-measure-2017-nimdm2017",
               target = "_blank",
               "here."
             )
@@ -601,7 +601,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
         of life through poor physical or mental health. More information can be
         viewed ",
             tags$a(
-              href = "https://www.gov.uk/government/statistics/english-indices-of-deprivation-2019",
+              href = "https://www.nisra.gov.uk/statistics/deprivation/northern-ireland-multiple-deprivation-measure-2017-nimdm2017",
               target = "_blank",
               "here."
             )
@@ -664,9 +664,9 @@ indicatorDescriptionsTest <- function() {
   )
   server <- function(input, output, session) {
     selected <- reactiveValues(
-      areas = vector(), geography = "northern_ireland_hsct_shp"
+      areas = vector(), geography = "northern_ireland_ltla_shp"
     )
-    indicatorDescriptionsServer("test", selected, type = "secondary_care")
+    indicatorDescriptionsServer("test", selected, type = "summary_metrics")
   }
   shinyApp(ui, server)
 }

--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -36,7 +36,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
               target = "_blank",
               "here."
             ),
-            " An interactice map to visualise these areas can be found",
+            " An interactive map to visualise these areas can be found",
             tags$a(
               href = "https://britishredcross.shinyapps.io/left-behind-areas/",
               target = "_blank",
@@ -163,7 +163,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
               target = "_blank",
               "here."
             ),
-            " An interactice map to visualise these areas can be found",
+            " An interactive map to visualise these areas can be found",
             tags$a(
               href = "https://britishredcross.shinyapps.io/left-behind-areas/",
               target = "_blank",
@@ -298,7 +298,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
               target = "_blank",
               "here."
             ),
-            " An interactice map to visualise these areas can be found",
+            " An interactive map to visualise these areas can be found",
             tags$a(
               href = "https://britishredcross.shinyapps.io/left-behind-areas/",
               target = "_blank",
@@ -388,7 +388,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
               target = "_blank",
               "here."
             ),
-            " An interactice map to visualise these areas can be found",
+            " An interactive map to visualise these areas can be found",
             tags$a(
               href = "https://britishredcross.shinyapps.io/left-behind-areas/",
               target = "_blank",
@@ -479,7 +479,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             ),
             " is England specific and provides an indication of health outcomes,
             risk factors, and the wider determinants of health. As part of the
-            British Red Cross Resilience Index, an equivalent version for 
+            British Red Cross Resilience Index, an equivalent version for
             Northern Ireland was created. More details of this index can be viewed ",
             tags$a(
               href = "https://github.com/britishredcrosssociety/resilience-index",
@@ -497,7 +497,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
               target = "_blank",
               "here."
             ),
-            " An interactice map to visualise these areas can be found",
+            " An interactive map to visualise these areas can be found",
             tags$a(
               href = "https://britishredcross.shinyapps.io/left-behind-areas/",
               target = "_blank",
@@ -521,10 +521,10 @@ indicatorDescriptionsServer <- function(id, selected, type) {
       } else if (selected$geography == "northern_ireland_ltla_shp" & type == "secondary_care") {
         tagList(
           tags$p(
-            "Provision of unpaid care covers looking after, giving help or support 
-            to anyone because they have long-term physical or mental health 
-            conditions or illnesses, or problems related to old age. It excludes 
-            any activities carried out in paid employment. More information can 
+            "Provision of unpaid care covers looking after, giving help or support
+            to anyone because they have long-term physical or mental health
+            conditions or illnesses, or problems related to old age. It excludes
+            any activities carried out in paid employment. More information can
             be viewed ",
             tags$a(
               href = "https://www.nisra.gov.uk/publications/census-2021-main-statistics-health-disability-and-unpaid-care-tables",
@@ -588,7 +588,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
               target = "_blank",
               "here."
             ),
-            " An interactice map to visualise these areas can be found",
+            " An interactive map to visualise these areas can be found",
             tags$a(
               href = "https://britishredcross.shinyapps.io/left-behind-areas/",
               target = "_blank",
@@ -607,7 +607,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- northern_ireland_hsct_secondary_care ----
       } else if (selected$geography == "northern_ireland_hsct_shp" & type == "secondary_care") {
         tagList(
@@ -638,7 +638,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- northern_ireland_hsct_demographics ----
       } else if (selected$geography == "northern_ireland_hsct_shp" & type == "demographics") {
         tagList(

--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -640,7 +640,7 @@ indicatorDescriptionsTest <- function() {
   )
   server <- function(input, output, session) {
     selected <- reactiveValues(
-      areas = vector(), geography = "england_ltla_shp"
+      areas = vector(), geography = "northern_ireland_ltla_shp"
     )
     indicatorDescriptionsServer("test", selected, type = "demographics")
   }

--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -55,7 +55,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- england_ltla_secondary_care ----
       } else if (selected$geography == "england_ltla_shp" & type == "secondary_care") {
         tagList(
@@ -116,7 +116,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- england_ltla_demographics ----
       } else if (selected$geography == "england_ltla_shp" & type == "demographics") {
         tagList(
@@ -131,7 +131,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- england_icb_summary_metrics ----
       } else if (selected$geography == "england_icb_shp" & type == "summary_metrics") {
         tagList(
@@ -182,7 +182,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- england_icb_secondary_care ----
       } else if (selected$geography == "england_icb_shp" & type == "secondary_care") {
         tagList(
@@ -243,7 +243,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- england_icb_demographics ----
       } else if (selected$geography == "england_icb_shp" & type == "demographics") {
         tagList(
@@ -258,7 +258,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- scotland_ltla_summary_metrics ----
       } else if (selected$geography == "scotland_ltla_shp" & type == "summary_metrics") {
         tagList(
@@ -318,7 +318,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- scotland_ltla_secondary_care ----
       } else if (selected$geography == "scotland_ltla_shp" & type == "secondary_care") {
         tagList(
@@ -333,7 +333,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- scotland_ltla_demographics ----
       } else if (selected$geography == "scotland_ltla_shp" & type == "demographics") {
         tagList(
@@ -348,7 +348,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- scotland_hb_summary_metrics ----
       } else if (selected$geography == "scotland_hb_shp" & type == "summary_metrics") {
         tagList(
@@ -408,7 +408,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- scotland_hb_secondary_care ----
       } else if (selected$geography == "scotland_hb_shp" & type == "secondary_care") {
         tagList(
@@ -444,7 +444,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- scotland_hb_demographics ----
       } else if (selected$geography == "scotland_hb_shp" & type == "demographics") {
         tagList(
@@ -471,11 +471,19 @@ indicatorDescriptionsServer <- function(id, selected, type) {
         in certain aspects of health."
           ),
           tags$p(
-            "The ONS Health Index provides an indication of health outcomes, risk
-        factors, and the wider determinants of health. A detailed breakdown
-        of the index can be viewed ",
+            "The ",
             tags$a(
               href = "https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/bulletins/healthinengland/2015to2021",
+              target = "_blank",
+              "ONS Health Index"
+            ),
+            " is England specific and provides an indication of health outcomes,
+            risk factors, and the wider determinants of health. As part of the
+            British Red Cross Resilience Index, an equivalent version for Northern Ireland
+            was created. More details of this index can
+            be viewed ",
+            tags$a(
+              href = "https://github.com/britishredcrosssociety/resilience-index",
               target = "_blank",
               "here."
             )
@@ -509,7 +517,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- northern_ireland_ltla_secondary_care ----
       } else if (selected$geography == "northern_ireland_ltla_shp" & type == "secondary_care") {
         tagList(
@@ -570,7 +578,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- northern_ireland_ltla_demographics ----
       } else if (selected$geography == "northern_ireland_ltla_shp" & type == "demographics") {
         tagList(
@@ -585,10 +593,11 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- northern_ireland_hsct_summary_metrics ----
       } else if (selected$geography == "northern_ireland_hsct_shp" & type == "summary_metrics") {
         tagList(
+          tagList(
           tags$p(
             "These indicators summarise a selection of health metrics into a single
         score. They can be useful for comparing the overall health of different
@@ -598,11 +607,19 @@ indicatorDescriptionsServer <- function(id, selected, type) {
         in certain aspects of health."
           ),
           tags$p(
-            "The ONS Health Index provides an indication of health outcomes, risk
-        factors, and the wider determinants of health. A detailed breakdown
-        of the index can be viewed ",
+            "The ",
             tags$a(
               href = "https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/bulletins/healthinengland/2015to2021",
+              target = "_blank",
+              "ONS Health Index"
+            ),
+            " is England specific and provides an indication of health outcomes,
+            risk factors, and the wider determinants of health. As part of the
+            British Red Cross Resilience Index, an equivalent version for Northern Ireland
+            was created. More details of this index can
+            be viewed ",
+            tags$a(
+              href = "https://github.com/britishredcrosssociety/resilience-index",
               target = "_blank",
               "here."
             )
@@ -636,7 +653,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- northern_ireland_hsct_secondary_care ----
       } else if (selected$geography == "northern_ireland_hsct_shp" & type == "secondary_care") {
         tagList(
@@ -697,7 +714,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-        
+
         # ---- northern_ireland_hsct_demographics ----
       } else if (selected$geography == "northern_ireland_hsct_shp" & type == "demographics") {
         tagList(
@@ -712,7 +729,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
             )
           )
         )
-      } 
+      }
     })
   })
 }

--- a/R/indicatorDescriptions.R
+++ b/R/indicatorDescriptions.R
@@ -534,7 +534,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
         the population breakdowns of the areas being assesed. All data come from
         the latest ",
             tags$a(
-              href = "https://www.ons.gov.uk/census",
+              href = "https://www.nisra.gov.uk/statistics/census/2021-census",
               target = "_blank",
               "2021 census."
             )
@@ -623,7 +623,7 @@ indicatorDescriptionsServer <- function(id, selected, type) {
         the population breakdowns of the areas being assesed. All data come from
         the latest ",
             tags$a(
-              href = "https://www.ons.gov.uk/census",
+              href = "https://www.nisra.gov.uk/statistics/census/2021-census",
               target = "_blank",
               "2021 census."
             )

--- a/R/jitterPlot.R
+++ b/R/jitterPlot.R
@@ -44,7 +44,7 @@ jitterPlotServer <- function(id, selected, type) {
           "demographics" = northern_ireland_ltla_demographics,
           stop("No data selected", call. = FALSE)
         )
-      }else if (selected$geography == "northern_ireland_hsct_shp") {
+      } else if (selected$geography == "northern_ireland_hsct_shp") {
         switch(type,
           "summary_metrics" = northern_ireland_hsct_summary_metrics,
           "secondary_care" = northern_ireland_hsct_secondary_care,

--- a/R/jitterPlot.R
+++ b/R/jitterPlot.R
@@ -37,6 +37,20 @@ jitterPlotServer <- function(id, selected, type) {
           "demographics" = scotland_hb_demographics,
           stop("No data selected", call. = FALSE)
         )
+      } else if (selected$geography == "northern_ireland_ltla_shp") {
+        switch(type,
+          "summary_metrics" = northern_ireland_ltla_summary_metrics,
+          "secondary_care" = northern_ireland_ltla_secondary_care,
+          "demographics" = northern_ireland_ltla_demographics,
+          stop("No data selected", call. = FALSE)
+        )
+      }else if (selected$geography == "northern_ireland_hsct_shp") {
+        switch(type,
+          "summary_metrics" = northern_ireland_hsct_summary_metrics,
+          "secondary_care" = northern_ireland_hsct_secondary_care,
+          "demographics" = northern_ireland_hsct_demographics,
+          stop("No data selected", call. = FALSE)
+        )
       }
     })
 

--- a/R/selectGeography.R
+++ b/R/selectGeography.R
@@ -6,7 +6,9 @@ selectGeographyUI <- function(id) {
       "England: Local Authorities" = "england_ltla_shp",
       "England: Integrated Care Boards" = "england_icb_shp",
       "Scotland: Local Authorities" = "scotland_ltla_shp",
-      "Scotland: Health Boards" = "scotland_hb_shp"
+      "Scotland: Health Boards" = "scotland_hb_shp",
+      "Northern Ireland: Local Authorities" = "northern_ireland_ltla_shp",
+      "Northern Ireland: Health and Social Care Trusts" = "northern_ireland_hsct_shp"
     ),
     multiple = FALSE
   )


### PR DESCRIPTION
Hey Mike, as stated in the title of the PR, I made both geographies of Northern Ireland available to the user of the HIE. 

I also made changes to jitterPlot.R to enable the creation of the Northern Ireland jitter plots. 

You will notice that I did not add `northern_ireland_ltla_shp` and `northern_ireland_hsct_shp` to data/. 
That is because Niuni will do it, along with adding the mapping of Northern Ireland to the HIE. 